### PR TITLE
docs: update branching strategy and add feature branch CI

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -1,10 +1,14 @@
-name: CI - dev
+name: CI - dev & feature branches
 
 on:
   push:
-    branches: [ dev ]
+    branches: 
+      - dev
+      - 'feature-issue-*'
   pull_request:
-    branches: [ dev ]
+    branches: 
+      - dev
+      - main
 
 jobs:
   build-and-test:

--- a/projectNIL/AGENTS.md
+++ b/projectNIL/AGENTS.md
@@ -19,15 +19,41 @@
 
 ## Branching Strategy
 
-This project follows a three-branch model:
+This project uses a multi-branch model with feature branches:
 
-| Branch | Purpose | CI | CD |
-|--------|---------|----|----|
-| `main` | Production branch | ✅ | ✅ |
-| `dev` | Development/integration branch | ✅ | ❌ |
-| `journal` | Onboarding logs & documentation | ❌ | ❌ |
+| Branch | Purpose | CI | CD | Merge to Main |
+|--------|---------|----|----|---------------|
+| `main` | Production branch | ✅ | ✅ | - |
+| `dev` | Technical tasks (non-feature work) | ✅ | ❌ | PR required, squash |
+| `journal` | Documentation entries | ❌ | ❌ | Daily squash, `[skip ci]`, no PR |
+| `feature-issue-<N>` | Feature work for issue #N | ✅ | ❌ | PR required, squash |
 
-**Important**: All commits to the `journal` branch **must include `[skip ci]` in the commit message** to prevent unnecessary CI triggers.
+### Branch Naming
+
+- **Feature branches**: `feature-issue-<number>` (e.g., `feature-issue-19`)
+- **Technical tasks**: Use `dev` branch directly
+- **Documentation**: Use `journal` branch
+
+### PR Requirements
+
+All merges to `main` require a Pull Request, **except** for journal merges:
+
+| Source Branch | PR Required | Merge Strategy |
+|---------------|-------------|----------------|
+| `dev` | ✅ Yes | Squash and merge |
+| `feature-issue-*` | ✅ Yes | Squash and merge |
+| `journal` | ❌ No | Squash and merge with `[skip ci]` |
+
+PRs should reference the issue number they address using `Closes #XX` in the PR description.
+
+### Journal Workflow
+
+Documentation entries follow this workflow:
+1. Commit to `journal` branch with `[skip ci]` in message
+2. Daily squash merge to `main` (no PR required)
+3. Use descriptive commit messages: `jour: <description> [skip ci]`
+
+**Important**: All commits to the `journal` branch **must include `[skip ci]`** to prevent unnecessary CI triggers.
 
 ## Commit Message Guidelines
 - Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style.

--- a/projectNIL/readme.md
+++ b/projectNIL/readme.md
@@ -1,6 +1,31 @@
 # Project NIL
 
- - towards a pedagogical CRUD to pick up on tooling and best practices
+Towards a pedagogical CRUD to pick up on tooling and best practices.
+
+## Documentation
+
+| Document | Description |
+|----------|-------------|
+| [AGENTS.md](./AGENTS.md) | Agentic coding guidelines, branching strategy, commit conventions |
+| [project-management.md](./project-management.md) | Issue types, Kanban workflow, GitHub CLI usage |
+| [effective-java.md](./effective-java.md) | Effective Java best practices reference |
+| [domain.org](./domain.org) | Domain modelling notes |
+| [progress.org](./progress.org) | Project progress tracking |
+
+### External Resources
+
+- [GitHub Project Board](https://github.com/orgs/nilenso/projects/24/views/1) - Kanban tracking issues
+- [Journal Branch](https://github.com/nilenso/raj-onboarding/tree/journal) - Daily documentation entries
+
+### Workflows
+
+| Workflow | Description |
+|----------|-------------|
+| **Project Management** | Issues tracked via GitHub Projects. See [project-management.md](./project-management.md) for CLI usage and conventions. |
+| **Journalling** | Daily entries on `journal` branch, squash-merged to `main` with `[skip ci]`. |
+| **Branching** | Feature work on `feature-issue-<N>` branches, technical tasks on `dev`. PRs required for all merges to `main` (except journal). |
+
+---
 
 ## Ideation (reverse chronological log)
 


### PR DESCRIPTION
## Summary
- Add documentation index to project readme
- Update branching strategy with feature-issue-* pattern
- Add CI triggers for feature branches and PRs to main

## Changes
- `projectNIL/readme.md`: Added documentation index with links to all docs, workflows overview
- `projectNIL/AGENTS.md`: Updated branching strategy, added PR requirements, journal workflow
- `.github/workflows/ci-dev.yml`: Added triggers for `feature-issue-*` branches and PRs to main

Closes #18