### PR TITLE
feat(api): implement PUT /functions/{id} for updating functions

### DIFF
--- a/projectNIL/services/api/src/main/java/com/projectnil/api/web/FunctionController.java
+++ b/projectNIL/services/api/src/main/java/com/projectnil/api/web/FunctionController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -82,6 +83,31 @@ public class FunctionController {
                 function.getStatus(),
                 function.getCreatedAt()
         ));
+    }
+
+    /**
+     * Update a function.
+     *
+     * <p>Per scope/contracts.md and issue #27:
+     * <ul>
+     *   <li>Updates name, description, language, source</li>
+     *   <li>If source or language changes, triggers recompilation</li>
+     *   <li>Returns expanded view with all fields</li>
+     * </ul>
+     *
+     * @param functionId the function ID
+     * @param request the update request
+     * @return the updated function (expanded view)
+     */
+    @PutMapping("/{functionId}")
+    public ResponseEntity<FunctionDetailResponse> update(
+            @PathVariable UUID functionId,
+            @RequestBody FunctionRequest request) {
+        LOG.debug("Received update function request: id={}", functionId);
+
+        FunctionDetailResponse response = functionService.update(functionId, request);
+
+        return ResponseEntity.ok(response);
     }
 
     /**

--- a/projectNIL/services/api/src/main/java/com/projectnil/api/web/FunctionDetailResponse.java
+++ b/projectNIL/services/api/src/main/java/com/projectnil/api/web/FunctionDetailResponse.java
@@ -1,0 +1,27 @@
+package com.projectnil.api.web;
+
+import com.projectnil.common.domain.FunctionStatus;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Expanded function response DTO.
+ *
+ * <p>Per scope/contracts.md, this is the expanded view returned for:
+ * <ul>
+ *   <li>GET /functions/{id}</li>
+ *   <li>PUT /functions/{id}</li>
+ * </ul>
+ */
+public record FunctionDetailResponse(
+    UUID id,
+    String name,
+    String description,
+    String language,
+    String source,
+    FunctionStatus status,
+    String compileError,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
+) {}


### PR DESCRIPTION
## Summary
- Implements `PUT /functions/{id}` endpoint to update functions
- Triggers recompilation when source or language changes, per `scope/flows.md`

## Changes
### New Files
- `FunctionDetailResponse.java` - Expanded view DTO for update responses

### Modified Files
- `FunctionService.java` - Added `update()` method with recompilation logic
- `FunctionController.java` - Added `PUT /functions/{id}` endpoint
- `FunctionControllerTest.java` - Added 7 integration tests for update scenarios
- `design-api-service.md` - Updated with implementation details (Section 10)

## Behavior
- Updates name, description, language, source
- If source or language changes:
  - Resets status to PENDING
  - Clears wasmBinary and compileError
  - Publishes new CompilationJob to queue
- Returns expanded view with all fields
- Returns 404 if function not found
- Returns 415 for unsupported language

## Testing
- 7 new tests for update scenarios
- All 24 API integration tests pass
- Build successful

## Closes
- #27 (Update a Function)