### PR TITLE
feat(api): implement executions query endpoints

### DIFF
--- a/projectNIL/services/api/src/main/java/com/projectnil/api/web/ExecutionController.java
+++ b/projectNIL/services/api/src/main/java/com/projectnil/api/web/ExecutionController.java
@@ -1,0 +1,52 @@
+package com.projectnil.api.web;
+
+import com.projectnil.api.service.ExecutionService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+/**
+ * REST controller for execution operations.
+ *
+ * <p>Provides endpoints for querying execution details per issue #30.
+ */
+@RestController
+@RequestMapping("/executions")
+public class ExecutionController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ExecutionController.class);
+
+    private final ExecutionService executionService;
+
+    public ExecutionController(ExecutionService executionService) {
+        this.executionService = executionService;
+    }
+
+    /**
+     * Get execution details by ID.
+     *
+     * <p>Per scope/contracts.md and issue #30:
+     * <ul>
+     *   <li>Returns detailed execution record including input, output, timestamps</li>
+     *   <li>Returns 404 if execution does not exist</li>
+     *   <li>errorMessage is included only for FAILED executions</li>
+     * </ul>
+     *
+     * @param executionId the execution ID
+     * @return the execution details
+     */
+    @GetMapping("/{executionId}")
+    public ResponseEntity<ExecutionDetailResponse> get(@PathVariable UUID executionId) {
+        LOG.debug("Received get execution request: id={}", executionId);
+
+        ExecutionDetailResponse response = executionService.getById(executionId);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/projectNIL/services/api/src/main/java/com/projectnil/api/web/ExecutionDetailResponse.java
+++ b/projectNIL/services/api/src/main/java/com/projectnil/api/web/ExecutionDetailResponse.java
@@ -1,0 +1,29 @@
+package com.projectnil.api.web;
+
+import com.projectnil.common.domain.ExecutionStatus;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Detailed execution response DTO.
+ *
+ * <p>Per scope/contracts.md and issue #30, includes all fields for inspection:
+ * <ul>
+ *   <li>id, functionId, status</li>
+ *   <li>input, output (JSON strings)</li>
+ *   <li>errorMessage (only populated if FAILED)</li>
+ *   <li>startedAt, completedAt, createdAt</li>
+ * </ul>
+ */
+public record ExecutionDetailResponse(
+    UUID id,
+    UUID functionId,
+    ExecutionStatus status,
+    String input,
+    String output,
+    String errorMessage,
+    LocalDateTime startedAt,
+    LocalDateTime completedAt,
+    LocalDateTime createdAt
+) {}

--- a/projectNIL/services/api/src/main/java/com/projectnil/api/web/ExecutionSummaryResponse.java
+++ b/projectNIL/services/api/src/main/java/com/projectnil/api/web/ExecutionSummaryResponse.java
@@ -1,0 +1,19 @@
+package com.projectnil.api.web;
+
+import com.projectnil.common.domain.ExecutionStatus;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Lightweight execution summary for list responses.
+ *
+ * <p>Per scope/contracts.md and issue #31, excludes heavy fields (input, output)
+ * to keep list responses lightweight.
+ */
+public record ExecutionSummaryResponse(
+    UUID id,
+    ExecutionStatus status,
+    LocalDateTime startedAt,
+    LocalDateTime completedAt
+) {}

--- a/projectNIL/services/api/src/main/java/com/projectnil/api/web/FunctionController.java
+++ b/projectNIL/services/api/src/main/java/com/projectnil/api/web/FunctionController.java
@@ -123,6 +123,30 @@ public class FunctionController {
     }
 
     /**
+     * List executions for a function.
+     *
+     * <p>Per scope/contracts.md and issue #31:
+     * <ul>
+     *   <li>Returns lightweight execution summaries (excludes input/output)</li>
+     *   <li>Ordered by startedAt DESC</li>
+     *   <li>Returns 404 if function does not exist</li>
+     *   <li>Returns empty list if no executions exist</li>
+     * </ul>
+     *
+     * @param functionId the function ID
+     * @return list of execution summaries
+     */
+    @GetMapping("/{functionId}/executions")
+    public ResponseEntity<List<ExecutionSummaryResponse>> listExecutions(
+            @PathVariable UUID functionId) {
+        LOG.debug("Received list executions request: functionId={}", functionId);
+
+        List<ExecutionSummaryResponse> executions = executionService.findByFunctionId(functionId);
+
+        return ResponseEntity.ok(executions);
+    }
+
+    /**
      * Execute a function with the given input.
      *
      * <p>Per scope/contracts.md and scope/practices.md:


### PR DESCRIPTION
## Summary
- Implements `GET /executions/{id}` for detailed execution view (#30)
- Implements `GET /functions/{id}/executions` for lightweight execution list (#31)

## Changes
### New Files
- `ExecutionController.java` - REST controller for `/executions` endpoints
- `ExecutionDetailResponse.java` - Detailed DTO with input, output, timestamps
- `ExecutionSummaryResponse.java` - Lightweight DTO for list (excludes input/output)

### Modified Files
- `ExecutionService.java` - Added `getById()` and `findByFunctionId()` methods
- `FunctionController.java` - Added `GET /functions/{id}/executions` endpoint
- `FunctionControllerTest.java` - Added 7 integration tests
- `design-api-service.md` - Updated with implementation details (Section 11)

## Behavior
### GET /executions/{id}
- Returns detailed execution record including input, output, timestamps
- Returns 404 if execution not found
- `errorMessage` included only for FAILED executions

### GET /functions/{id}/executions
- Returns lightweight summaries ordered by startedAt DESC
- Excludes heavy fields (input, output) for performance
- Returns 404 if function not found
- Returns empty list if no executions

## Testing
- 7 new tests for execution query scenarios
- All 38 API integration tests pass
- Build successful

## Closes
- #30 (Get Execution Details)
- #31 (List Executions for a Function)