### PR TITLE
feat(api): enforce canonical DTO serialization

### DIFF
--- a/projectNIL/docs/design-api-service.md
+++ b/projectNIL/docs/design-api-service.md
@@ -575,7 +575,60 @@ public ResponseEntity<List<ExecutionSummaryResponse>> listExecutions(
 
 ---
 
-## 12. Next Steps (Recommended Order)
+## 12. Canonical DTO Alignment (#55)
+
+Per `scope/contracts.md`, this section details DTO serialization alignment.
+
+### 12.1 Changes
+
+| DTO | Field | Before | After |
+|-----|-------|--------|-------|
+| `ExecutionResponse` | `output` | `String` | `Object` (parsed JSON) |
+| `ExecutionDetailResponse` | `input` | `String` | `Object` (parsed JSON) |
+| `ExecutionDetailResponse` | `output` | `String` | `Object` (parsed JSON) |
+| `ExecutionRequest` | `input` | `Object` (any) | `Object` (validated as Map) |
+
+### 12.2 Input Validation
+
+Per `scope/contracts.md`, `ExecutionRequest.input` must be a JSON object:
+
+```java
+private String serializeInput(Object input) {
+    if (input == null) {
+        return "{}";
+    }
+    if (!(input instanceof java.util.Map)) {
+        throw new InvalidInputException(
+                "Input must be a JSON object, got: " + input.getClass().getSimpleName());
+    }
+    return objectMapper.writeValueAsString(input);
+}
+```
+
+### 12.3 Output Parsing
+
+Output is parsed from JSON string to Object for response:
+
+```java
+private Object parseOutput(String outputJson) {
+    if (outputJson == null || outputJson.isBlank()) {
+        return null;
+    }
+    return objectMapper.readValue(outputJson, Object.class);
+}
+```
+
+### 12.4 Error Handling
+
+| Scenario | HTTP Response |
+|----------|---------------|
+| Input is primitive (string/number) | 400 Bad Request |
+| Input is array | 400 Bad Request |
+| Input is null | Treated as `{}` |
+
+---
+
+## 13. Next Steps (Recommended Order)
 
 1. ~~**Database configuration** - Add datasource config to `application.yaml`~~ Done
 2. ~~**Repositories** - Create `FunctionRepository` and `ExecutionRepository`~~ Done
@@ -584,4 +637,5 @@ public ResponseEntity<List<ExecutionSummaryResponse>> listExecutions(
 5. ~~**FunctionController CRUD** - REST endpoints for function management~~ Done
 6. ~~**PUT /functions/{id}** - Update function and recompile~~ Done (#27)
 7. ~~**Execution queries** - `GET /executions/{id}` and `GET /functions/{id}/executions`~~ Done (#30, #31)
+8. ~~**DTO Alignment** - Canonical serialization per scope/contracts.md~~ Done (#55)
 

--- a/projectNIL/services/api/src/main/java/com/projectnil/api/service/InvalidInputException.java
+++ b/projectNIL/services/api/src/main/java/com/projectnil/api/service/InvalidInputException.java
@@ -1,0 +1,13 @@
+package com.projectnil.api.service;
+
+/**
+ * Exception thrown when execution input is invalid.
+ *
+ * <p>Per scope/contracts.md, ExecutionRequest.input must be a JSON object.
+ */
+public class InvalidInputException extends RuntimeException {
+
+    public InvalidInputException(String message) {
+        super(message);
+    }
+}

--- a/projectNIL/services/api/src/main/java/com/projectnil/api/web/ExecutionDetailResponse.java
+++ b/projectNIL/services/api/src/main/java/com/projectnil/api/web/ExecutionDetailResponse.java
@@ -11,7 +11,7 @@ import java.util.UUID;
  * <p>Per scope/contracts.md and issue #30, includes all fields for inspection:
  * <ul>
  *   <li>id, functionId, status</li>
- *   <li>input, output (JSON strings)</li>
+ *   <li>input, output (parsed JSON objects per #55)</li>
  *   <li>errorMessage (only populated if FAILED)</li>
  *   <li>startedAt, completedAt, createdAt</li>
  * </ul>
@@ -20,8 +20,8 @@ public record ExecutionDetailResponse(
     UUID id,
     UUID functionId,
     ExecutionStatus status,
-    String input,
-    String output,
+    Object input,
+    Object output,
     String errorMessage,
     LocalDateTime startedAt,
     LocalDateTime completedAt,

--- a/projectNIL/services/api/src/main/java/com/projectnil/api/web/ExecutionResponse.java
+++ b/projectNIL/services/api/src/main/java/com/projectnil/api/web/ExecutionResponse.java
@@ -1,14 +1,27 @@
 package com.projectnil.api.web;
 
 import com.projectnil.common.domain.ExecutionStatus;
+
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * Response DTO for function execution.
+ *
+ * <p>Per scope/contracts.md, output is returned as a parsed JSON object, not a string.
+ *
+ * @param id the execution ID
+ * @param functionId the function ID
+ * @param status the execution status
+ * @param output the parsed JSON output (null if failed)
+ * @param errorMessage error message (only for FAILED status)
+ * @param createdAt when the execution was created
+ */
 public record ExecutionResponse(
     UUID id,
     UUID functionId,
     ExecutionStatus status,
-    String output,
+    Object output,
     String errorMessage,
     LocalDateTime createdAt
 ) {}

--- a/projectNIL/services/api/src/main/java/com/projectnil/api/web/GlobalExceptionHandler.java
+++ b/projectNIL/services/api/src/main/java/com/projectnil/api/web/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.projectnil.api.runtime.WasmAbiException;
 import com.projectnil.api.service.ExecutionNotFoundException;
 import com.projectnil.api.service.FunctionNotFoundException;
 import com.projectnil.api.service.FunctionNotReadyException;
+import com.projectnil.api.service.InvalidInputException;
 import com.projectnil.api.service.UnsupportedLanguageException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,6 +57,13 @@ public class GlobalExceptionHandler {
         LOG.warn("Unsupported language: {}", ex.getRequestedLanguage());
         return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
                 .body(errorBody(HttpStatus.UNSUPPORTED_MEDIA_TYPE, ex.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidInputException.class)
+    public ResponseEntity<Map<String, Object>> handleInvalidInput(InvalidInputException ex) {
+        LOG.warn("Invalid input: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(errorBody(HttpStatus.BAD_REQUEST, ex.getMessage()));
     }
 
     @ExceptionHandler(WasmAbiException.class)


### PR DESCRIPTION
## Summary
- Aligns DTO serialization with `scope/contracts.md` canonical contracts
- Returns `output` and `input` as parsed JSON objects instead of strings
- Validates `ExecutionRequest.input` is a JSON object (rejects primitives/arrays)

## Changes
### Modified Files
- `ExecutionResponse.java` - `output` changed from `String` to `Object`
- `ExecutionDetailResponse.java` - `input`/`output` changed from `String` to `Object`
- `ExecutionService.java` - Added `parseOutput()` and input validation in `serializeInput()`
- `GlobalExceptionHandler.java` - Added handler for `InvalidInputException`
- `FunctionControllerTest.java` - Updated tests for parsed JSON output, added 5 new tests

### New Files
- `InvalidInputException.java` - Exception for invalid input validation

## Behavior Changes

### Before
```json
{
  "output": "{\"sum\": 15}"
}
```

### After
```json
{
  "output": { "sum": 15 }
}
```

### Input Validation
- `{"input": {"a": 5}}` - Accepted
- `{"input": null}` - Accepted (treated as `{}`)
- `{"input": "string"}` - Rejected (400)
- `{"input": [1, 2]}` - Rejected (400)

## Testing
- 5 new tests for DTO serialization
- All 48 API integration tests pass
- Build successful

## Closes
- #55 (API: Enforce canonical function + execution DTOs)