### PR TITLE
Add MkDocs documentation site with GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,58 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'projectNIL/docs/**'
+      - 'projectNIL/mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install MkDocs and dependencies
+        run: |
+          pip install mkdocs-material pymdown-extensions
+
+      - name: Build documentation
+        working-directory: projectNIL
+        run: mkdocs build --strict
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: projectNIL/site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/projectNIL/.gitignore
+++ b/projectNIL/.gitignore
@@ -3,3 +3,6 @@
 
 # Ignore Gradle build output directory
 build
+
+# MkDocs generated site
+site/

--- a/projectNIL/docs/README.md
+++ b/projectNIL/docs/README.md
@@ -1,6 +1,16 @@
 # ProjectNIL
 
+[![CI](https://github.com/nilenso/raj-onboarding/actions/workflows/integrations.yml/badge.svg?branch=dev)](https://github.com/nilenso/raj-onboarding/actions/workflows/integrations.yml)
+[![Deployment](https://github.com/nilenso/raj-onboarding/actions/workflows/deployment.yml/badge.svg)](https://github.com/nilenso/raj-onboarding/actions/workflows/deployment.yml)
+
 A Function as a Service (FaaS) platform. Users submit source code, it compiles to WebAssembly, and executes on demand in a sandboxed environment.
+
+| Metric | Status |
+|--------|--------|
+| **Phase** | Phase 0 Complete |
+| **Tests** | 64 passing (6 common, 48 API, 10 compiler) |
+| **API Endpoints** | 9 implemented |
+| **Languages** | AssemblyScript |
 
 > **Note:** `projectNIL/scope/` is the canonical specification. This doc summarizes the system and focuses on operational context.
 
@@ -9,7 +19,7 @@ A Function as a Service (FaaS) platform. Users submit source code, it compiles t
 - **[Getting Started Guide](./guides/getting-started.md)** - Set up and run your first function
 - **[Writing Functions Guide](./guides/writing-functions.md)** - Learn how to write AssemblyScript functions
 - **[API Reference](./api.md)** - Complete endpoint documentation
-- **[Canonical Contracts](../scope/contracts.md)** - Authoritative API and queue contracts
+- **[Canonical Contracts](https://github.com/nilenso/raj-onboarding/blob/main/projectNIL/scope/contracts.md)** - Authoritative API and queue contracts
 
 ## Architecture
 
@@ -33,7 +43,7 @@ flowchart LR
   API -->|execute WASM| Wasm[WASM Runtime]
 ```
 
-See [scope/architecture.md](../scope/architecture.md) for the canonical architecture specification.
+See the [scope/architecture.md](https://github.com/nilenso/raj-onboarding/blob/main/projectNIL/scope/architecture.md) for the canonical architecture specification.
 
 ## Services
 
@@ -118,7 +128,7 @@ podman exec -it projectnil-db psql -U projectnil -d projectnil
 | Compiler | AssemblyScript | Latest |
 | Containers | Podman Compose | - |
 
-See [stack.md](./stack.md) for rationale and [decisions/](./decisions/) for ADRs.
+See [stack.md](./stack.md) for rationale.
 
 ## Project Structure
 
@@ -171,16 +181,16 @@ projectNIL/
 - [Compiler Service](./compiler.md) - Compilation pipeline
 - [Infrastructure](./infrastructure.md) - Deployment and ops
 
-### Specifications
-- [Canonical Contracts](../scope/contracts.md) - Source of truth for APIs
-- [Domain Entities](../scope/entities.md) - Entity definitions and state machines
-- [System Flows](../scope/flows.md) - End-to-end sequences
+### Specifications (GitHub)
+- [Canonical Contracts](https://github.com/nilenso/raj-onboarding/blob/main/projectNIL/scope/contracts.md) - Source of truth for APIs
+- [Domain Entities](https://github.com/nilenso/raj-onboarding/blob/main/projectNIL/scope/entities.md) - Entity definitions and state machines
+- [System Flows](https://github.com/nilenso/raj-onboarding/blob/main/projectNIL/scope/flows.md) - End-to-end sequences
+- [AGENTS.md](https://github.com/nilenso/raj-onboarding/blob/main/projectNIL/AGENTS.md) - Coding conventions
 
 ### Project
 - [Roadmap](./roadmap.md) - Phase 0/1/2 plans
 - [Session Handoff](./session-handoff.md) - Current implementation status
 - [Design: API Service](./design-api-service.md) - Implementation blueprint
-- [AGENTS.md](../AGENTS.md) - Coding conventions
 
 ### Architecture Decisions
 - [ADR-001: WASM Runtime](./decisions/001-wasm-runtime.md) - Why Chicory

--- a/projectNIL/docs/api.md
+++ b/projectNIL/docs/api.md
@@ -2,7 +2,14 @@
 
 Canonical API contracts live in `projectNIL/scope/contracts.md`.
 
-Base URL: `http://localhost:8080`
+## Base URL
+
+| Environment | URL |
+|-------------|-----|
+| **Production** | `{{ PRODUCTION_API_URL }}` |
+| **Local** | `http://localhost:8080` |
+
+> Set `API_URL` environment variable to your target environment before running examples.
 
 ---
 

--- a/projectNIL/mkdocs.yml
+++ b/projectNIL/mkdocs.yml
@@ -1,0 +1,83 @@
+site_name: ProjectNIL
+site_description: Function as a Service Platform
+site_url: https://nilenso.github.io/raj-onboarding/
+repo_url: https://github.com/nilenso/raj-onboarding
+repo_name: nilenso/raj-onboarding
+
+docs_dir: docs
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.highlight
+    - search.suggest
+    - content.code.copy
+    - content.code.annotate
+
+markdown_extensions:
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: "!!python/name:pymdownx.superfences.fence_code_format"
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - admonition
+  - pymdownx.details
+  - attr_list
+  - md_in_html
+  - toc:
+      permalink: true
+
+plugins:
+  - search
+
+nav:
+  - Home: README.md
+  - User Guides:
+    - Getting Started: guides/getting-started.md
+    - Writing Functions: guides/writing-functions.md
+  - Reference:
+    - API Reference: api.md
+    - WASM Runtime: wasm-runtime.md
+    - Compiler Service: compiler.md
+  - Operations:
+    - Infrastructure: infrastructure.md
+    - Testing Strategy: testing-strategy.md
+    - Deployment Roadmap: deployment-roadmap.md
+  - Architecture:
+    - Design: design-api-service.md
+    - Tech Stack: stack.md
+    - Roadmap: roadmap.md
+  - Decisions:
+    - ADR-001 WASM Runtime: decisions/001-wasm-runtime.md
+    - ADR-002 Message Queue: decisions/002-message-queue-pgmq.md
+  - Session Handoff: session-handoff.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/nilenso/raj-onboarding


### PR DESCRIPTION
## Summary
- Add static documentation site using MkDocs with Material theme
- Configure GitHub Actions to deploy docs to GitHub Pages on push to main
- Update documentation to support production URL environment variable

## Changes

### New Files
- `mkdocs.yml` - MkDocs configuration with Material theme, mermaid support, search
- `.github/workflows/docs.yml` - GitHub Actions workflow for docs deployment

### Updated Docs
- `docs/README.md` - Add CI/CD status badges, fix external links
- `docs/api.md` - Add production/local URL table
- `docs/guides/getting-started.md` - Use `$API_URL` variable pattern

## Features
- Material theme with dark/light mode toggle
- Built-in search
- Mermaid diagram support
- Code syntax highlighting with copy button
- Automatic deployment on push to main

## Deployment
After merge, docs will be available at:
https://nilenso.github.io/raj-onboarding/

## Note
GitHub Pages needs to be enabled in repository settings after first deployment.